### PR TITLE
Fix UUID validation for Supabase design saving

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -23,7 +23,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     console.log("Setting up auth state listener");
-    
+
     // Set up auth state listener FIRST
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       (event, newSession) => {
@@ -39,12 +39,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       try {
         console.log("Checking for existing session");
         const { data: { session: existingSession }, error } = await supabase.auth.getSession();
-        
+
         if (error) {
           console.error("Error getting session:", error);
           return;
         }
-        
+
         if (existingSession) {
           console.log("Found existing session for user:", existingSession.user?.email);
           setSession(existingSession);
@@ -69,40 +69,40 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const signIn = async (email: string, password: string) => {
     console.log("Attempting to sign in user:", email);
-    
+
     // For test credentials from docs/test_file
     if (email === "kmandalam@gmail.com" && password === "12345678") {
       console.log("Using test credentials");
       const mockUser = {
-        id: "test-user-id",
+        id: "0ad70049-b2a7-4248-a395-811665c971fe", // Valid UUID format for testing
         email: "kmandalam@gmail.com",
         user_metadata: {
           name: "Test User"
         }
       } as unknown as User;
-      
+
       const mockSession = {
         access_token: "mock-token",
         refresh_token: "mock-refresh",
         user: mockUser
       } as unknown as Session;
-      
+
       setUser(mockUser);
       setSession(mockSession);
       return;
     }
-    
+
     try {
-      const { error, data } = await supabase.auth.signInWithPassword({ 
-        email, 
+      const { error, data } = await supabase.auth.signInWithPassword({
+        email,
         password
       });
-      
+
       if (error) {
         console.error("Sign in error:", error.message);
         throw error;
       }
-      
+
       if (data?.session) {
         console.log("Sign in successful for:", data.user?.email);
         setSession(data.session);
@@ -121,7 +121,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const signUp = async (email: string, password: string, fullName: string) => {
     console.log("Attempting to sign up user:", email);
     try {
-      const { error, data } = await supabase.auth.signUp({ 
+      const { error, data } = await supabase.auth.signUp({
         email,
         password,
         options: {
@@ -130,14 +130,14 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           }
         }
       });
-      
+
       if (error) {
         console.error("Sign up error:", error.message);
         throw error;
       }
-      
+
       console.log("Sign up response:", data);
-      
+
       if (data?.user) {
         // Check if email confirmation is required
         if (data.session) {
@@ -163,19 +163,19 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     console.log("Attempting to sign out user");
     try {
       // For test user
-      if (user?.email === "kmandalam@gmail.com") {
+      if (user?.email === "kmandalam@gmail.com" || user?.id === "0ad70049-b2a7-4248-a395-811665c971fe") {
         console.log("Signing out test user");
         setUser(null);
         setSession(null);
         return;
       }
-      
+
       const { error } = await supabase.auth.signOut();
       if (error) {
         console.error("Sign out error:", error.message);
         throw error;
       }
-      
+
       console.log("User signed out successfully");
       setUser(null);
       setSession(null);
@@ -187,14 +187,14 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ 
-      user, 
+    <AuthContext.Provider value={{
+      user,
       session,
-      loading, 
+      loading,
       signIn,
-      signUp, 
-      signOut, 
-      isAuthenticated: !!user 
+      signUp,
+      signOut,
+      isAuthenticated: !!user
     }}>
       {children}
     </AuthContext.Provider>

--- a/src/hooks/useDesignAPI.ts
+++ b/src/hooks/useDesignAPI.ts
@@ -38,6 +38,14 @@ export function useDesignAPI() {
       return { success: false, error: "User ID is required" };
     }
 
+    // Validate UUID format
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(userId)) {
+      console.error("Invalid UUID format for user ID:", userId);
+      setError("Invalid user ID format");
+      return { success: false, error: "Invalid user ID format" };
+    }
+
     try {
       console.log("Saving design for user:", userId);
       setLoading(true);

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -61,7 +61,7 @@ export type Database = {
           name: string
           preview_url: string | null
           question_responses: Json | null
-          user_id: string | null
+          user_id: string | null // UUID format required
           user_style_metadata: Json | null
         }
         Insert: {
@@ -73,7 +73,7 @@ export type Database = {
           name?: string
           preview_url?: string | null
           question_responses?: Json | null
-          user_id?: string | null
+          user_id?: string | null // UUID format required
           user_style_metadata?: Json | null
         }
         Update: {
@@ -85,7 +85,7 @@ export type Database = {
           name?: string
           preview_url?: string | null
           question_responses?: Json | null
-          user_id?: string | null
+          user_id?: string | null // UUID format required
           user_style_metadata?: Json | null
         }
         Relationships: []

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -7,7 +7,8 @@ export type Json =
   | { [key: string]: Json | undefined }
   | Json[]
 
-export interface Database {
+// Renamed to avoid conflict with supabase/types.ts
+export interface AppDatabase {
   public: {
     Tables: {
       sample_images: {


### PR DESCRIPTION
- Update test user ID to use valid UUID format (0ad70049-b2a7-4248-a395-811665c971fe)
- Add UUID format validation in useDesignAPI.ts
- Fix duplicate Database type definition by renaming in database.types.ts
- Add comments to indicate UUID format requirement in Supabase types

This fixes the 'invalid input syntax for type uuid' error when saving designs to Supabase with test user credentials.